### PR TITLE
Fix wrong audio sample rate on suspend/resume when using internal clock

### DIFF
--- a/sound/pci/hdsp/hdspe/hdspe_core.c
+++ b/sound/pci/hdsp/hdspe/hdspe_core.c
@@ -750,6 +750,10 @@ static int __maybe_unused snd_hdspe_resume(struct pci_dev *dev)
 	hdspe_write_settings(hdspe);
 	hdspe_write_control(hdspe);
 
+	/* Set PLL frequency from restored registers */
+	dev_dbg(hdspe->card->dev, "Restoring PLL freq\n");
+	hdspe_write_pll_freq(hdspe);
+
 	/* Resume mixer? hdspe_init_mixer just allocates memory ... */
 
 	/* (5) Restart the chip or hardware */


### PR DESCRIPTION
I have an HDSPe AIO and noticed that when using internal clock at 48kHz, after suspend/resume the audio was slowed down.

With the program "hdspeconf" I could see that the Pitch was all the way down (and then some), as well as the Sample Rate was showing as "44100" even though the internal clock was showing as supposedly configured to run at 48kHz.

This commit fixed it for me.