### PR TITLE
Replace function from_timer with time_container_of for kernel v6.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 New linux kernel ALSA driver for [RME](http://www.rme-audio.com) HDSPe MADI / AES / RayDAT / AIO and AIO Pro sound cards and extension modules.
 
 Forked from [snd-hdspe](https://github.com/PhilippeBekaert/snd-hdspe) which is no longer maintained as Prof. Dr. Philippe Bekaert passed away in 2022.  
-This fork's `main` branch contains kernel compatibility updates for newer kernels (v5.12, v6.2). The `develop` branch contains WIP features like suspend/resume support, improved logging (debug/production levels) and fixes various compiler warnings.
+This fork's `main` branch contains kernel compatibility updates for newer kernels (v5.12, v6.2, v6.16). The `develop` branch contains WIP features like suspend/resume support, improved logging (debug/production levels) and fixes various compiler warnings.
 
 **Original README text**  
 New linux kernel ALSA driver for [RME](http://www.rme-audio.com) HDSPe MADI / AES / RayDAT / AIO and AIO Pro sound cards and extension modules.

--- a/sound/pci/hdsp/hdspe/hdspe_midi.c
+++ b/sound/pci/hdsp/hdspe/hdspe_midi.c
@@ -166,7 +166,12 @@ snd_hdspe_midi_input_trigger(struct snd_rawmidi_substream *substream, int up)
 
 static void snd_hdspe_midi_output_timer(struct timer_list *t)
 {
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
+	struct hdspe_midi *hmidi = timer_container_of(hmidi, t, timer);
+#else
 	struct hdspe_midi *hmidi = from_timer(hmidi, t, timer);
+#endif
 	unsigned long flags;
 
 	snd_hdspe_midi_output_write(hmidi);


### PR DESCRIPTION
Fixes compiling for kernel v6.16

Tested with
Linux 6.16.0-5-cachyos SMP PREEMPT_DYNAMIC x86_64 GNU/Linux